### PR TITLE
humble/fix: fixed accidental backgrounding

### DIFF
--- a/humble_collection.yml
+++ b/humble_collection.yml
@@ -47,7 +47,7 @@ script:
 
         echo "$FIXED_SCHEME" > $GAMEDIR/drive_c/.auth
 
-        if command -v lutris 1&>/dev/null; then
+        if command -v lutris 1>/dev/null; then
 
           lutris $LUTRIS_CMD
 


### PR DESCRIPTION
Fixes #6 

No longer backgrounding `command` calls since on some distros that causes the if statement to fall into the first branch regardless.